### PR TITLE
Problem: can't build rpm package

### DIFF
--- a/packaging/debian/libfty-proto-dev.install
+++ b/packaging/debian/libfty-proto-dev.install
@@ -1,5 +1,6 @@
 usr/include/*
 usr/lib/*/libfty_proto.so
 usr/lib/*/pkgconfig/libfty_proto.pc
+usr/share/zproject
 usr/share/man/man3/*
 usr/share/man/man7/*

--- a/packaging/redhat/fty-proto.spec
+++ b/packaging/redhat/fty-proto.spec
@@ -89,6 +89,13 @@ This package contains development files for fty-proto: 42ity core protocols
 %{_mandir}/man3/*
 %{_mandir}/man7/*
 
+
+# Install api files into /usr/local/share/zproject
+%dir %{_datadir}/zproject/
+%dir %{_datadir}/zproject/fty-proto
+%dir %{_datadir}/zproject/fty-proto/*.api
+
+
 %prep
 %setup -q
 


### PR DESCRIPTION
Solution: regenerate using latest zproto to have a file list

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>