### PR TITLE
Problem: need to update generated LUA bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,9 @@ compile_commands.json
 DartConfiguration.tcl
 install_manifest.txt
 Testing/
+builds/cmake/
+CMake*
+*.cmake
 
 # Repositories downloaded by CI integration scripts
 libzmq/

--- a/bindings/lua_ffi/fty_proto_ffi.lua
+++ b/bindings/lua_ffi/fty_proto_ffi.lua
@@ -74,12 +74,26 @@ int
     fty_proto_send_again (fty_proto_t *self, void *output);
 
 // Encode the METRIC
+/* NOTE: Manual edit here - two couples of old function signatures were left
+ * in place by editors before me (commented away below); I'd leave it up
+ * to experts to fix this if needed */
+
+zmsg_t *
+    fty_proto_encode_metric (zhash_t *aux, uint64_t time, uint32_t ttl, const char *type, const char *name, const char *value, const char *unit);
+
+/*
 zmsg_t *
     fty_proto_encode_metric (zhash_t *aux, const char *type, const char *name, const char *value, const char *unit, uint32_t ttl, uint64_t time);
+*/
 
 // Encode the ALERT
 zmsg_t *
+    fty_proto_encode_alert (zhash_t *aux, uint64_t time, uint32_t ttl, const char *rule, const char *name, const char *state, const char *severity, const char *description, const char *action);
+
+/*
+zmsg_t *
     fty_proto_encode_alert (zhash_t *aux, const char *rule, const char *name, const char *state, const char *severity, const char *description, uint64_t time, const char *action, uint32_t ttl);
+*/
 
 // Encode the ASSET
 zmsg_t *
@@ -88,12 +102,22 @@ zmsg_t *
 // Send the METRIC to the output in one step                    
 // WARNING, this call will fail if output is of type ZMQ_ROUTER.
 int
+    fty_proto_send_metric (void *output, zhash_t *aux, uint64_t time, uint32_t ttl, const char *type, const char *name, const char *value, const char *unit);
+
+/*
+int
     fty_proto_send_metric (void *output, zhash_t *aux, const char *type, const char *name, const char *value, const char *unit, uint32_t ttl, uint64_t time);
+*/
 
 // Send the ALERT to the output in one step                     
 // WARNING, this call will fail if output is of type ZMQ_ROUTER.
 int
+    fty_proto_send_alert (void *output, zhash_t *aux, uint64_t time, uint32_t ttl, const char *rule, const char *name, const char *state, const char *severity, const char *description, const char *action);
+
+/*
+int
     fty_proto_send_alert (void *output, zhash_t *aux, const char *rule, const char *name, const char *state, const char *severity, const char *description, uint64_t time, const char *action, uint32_t ttl);
+*/
 
 // Send the ASSET to the output in one step                     
 // WARNING, this call will fail if output is of type ZMQ_ROUTER.

--- a/bindings/lua_ffi/fty_proto_ffi.lua
+++ b/bindings/lua_ffi/fty_proto_ffi.lua
@@ -184,6 +184,22 @@ void
 size_t
     fty_proto_aux_size (fty_proto_t *self);
 
+// Get/set the time field
+uint64_t
+    fty_proto_time (fty_proto_t *self);
+
+// Get/set the time field
+void
+    fty_proto_set_time (fty_proto_t *self, uint64_t time);
+
+// Get/set the ttl field
+uint32_t
+    fty_proto_ttl (fty_proto_t *self);
+
+// Get/set the ttl field
+void
+    fty_proto_set_ttl (fty_proto_t *self, uint32_t ttl);
+
 // Get/set the type field
 const char *
     fty_proto_type (fty_proto_t *self);
@@ -215,22 +231,6 @@ const char *
 // Get/set the unit field
 void
     fty_proto_set_unit (fty_proto_t *self, const char *format, ...);
-
-// Get/set the ttl field
-uint32_t
-    fty_proto_ttl (fty_proto_t *self);
-
-// Get/set the ttl field
-void
-    fty_proto_set_ttl (fty_proto_t *self, uint32_t ttl);
-
-// Get/set the time field
-uint64_t
-    fty_proto_time (fty_proto_t *self);
-
-// Get/set the time field
-void
-    fty_proto_set_time (fty_proto_t *self, uint64_t time);
 
 // Get/set the rule field
 const char *

--- a/bindings/lua_ffi/fty_proto_ffi.lua
+++ b/bindings/lua_ffi/fty_proto_ffi.lua
@@ -74,26 +74,12 @@ int
     fty_proto_send_again (fty_proto_t *self, void *output);
 
 // Encode the METRIC
-/* NOTE: Manual edit here - two couples of old function signatures were left
- * in place by editors before me (commented away below); I'd leave it up
- * to experts to fix this if needed */
-
 zmsg_t *
     fty_proto_encode_metric (zhash_t *aux, uint64_t time, uint32_t ttl, const char *type, const char *name, const char *value, const char *unit);
-
-/*
-zmsg_t *
-    fty_proto_encode_metric (zhash_t *aux, const char *type, const char *name, const char *value, const char *unit, uint32_t ttl, uint64_t time);
-*/
 
 // Encode the ALERT
 zmsg_t *
     fty_proto_encode_alert (zhash_t *aux, uint64_t time, uint32_t ttl, const char *rule, const char *name, const char *state, const char *severity, const char *description, const char *action);
-
-/*
-zmsg_t *
-    fty_proto_encode_alert (zhash_t *aux, const char *rule, const char *name, const char *state, const char *severity, const char *description, uint64_t time, const char *action, uint32_t ttl);
-*/
 
 // Encode the ASSET
 zmsg_t *
@@ -104,20 +90,10 @@ zmsg_t *
 int
     fty_proto_send_metric (void *output, zhash_t *aux, uint64_t time, uint32_t ttl, const char *type, const char *name, const char *value, const char *unit);
 
-/*
-int
-    fty_proto_send_metric (void *output, zhash_t *aux, const char *type, const char *name, const char *value, const char *unit, uint32_t ttl, uint64_t time);
-*/
-
 // Send the ALERT to the output in one step                     
 // WARNING, this call will fail if output is of type ZMQ_ROUTER.
 int
     fty_proto_send_alert (void *output, zhash_t *aux, uint64_t time, uint32_t ttl, const char *rule, const char *name, const char *state, const char *severity, const char *description, const char *action);
-
-/*
-int
-    fty_proto_send_alert (void *output, zhash_t *aux, const char *rule, const char *name, const char *state, const char *severity, const char *description, uint64_t time, const char *action, uint32_t ttl);
-*/
 
 // Send the ASSET to the output in one step                     
 // WARNING, this call will fail if output is of type ZMQ_ROUTER.


### PR DESCRIPTION
Function signatures in LUA bindings previously saved in the repo and generated by zproject are different (TTL moved around). Someone needs to revise this.