### PR TITLE
Problem: Need to test and benefit from recent zproject improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,6 @@ core
 fty-proto-1.0.0/
 fty-proto-1.0.0.tar.gz
 fty-proto-1.0.0.zip
-ftyproto-0.1.0/
-ftyproto-0.1.0.tar.gz
-ftyproto-0.1.0.zip
 
 # Man pages
 doc/*.1
@@ -58,6 +55,7 @@ config.log
 config.status
 config/
 configure
+configure.lineno
 libtool
 src/platform.h
 src/platform.h.in

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,28 @@
 # This is a skeleton created by zproject.
 # You can add hand-written code here.
 
-language: c
+language:
+- c
 
-cache: ccache
+cache:
+- ccache
 
 os:
 - linux
 
+# Note: some packages or dependencies may require extended permissions
+# which take longer to set up and boot. If your project does not build
+# in the default container with sudo==false, consider requiring a docker
+# image and/or a newer Ubuntu Trusty baseline VM, by uncommenting below.
+# See the current docs on http://travis-ci.org for up-to-date options.
 sudo: false
+#sudo: required
 
-services:
-- docker
+#dist:
+#- trusty
+
+#services:
+#- docker
 
 # Set CI_TIME=true to enable build-step profiling in Travis
 # Set CI_TRACE=true to enable shell script tracing in Travis
@@ -21,7 +32,7 @@ env:
   global:
     - CI_TIME=false
     - CI_TRACE=false
-    - CI_QUIET=true
+    - CI_CONFIG_QUIET=true
   matrix:
     - BUILD_TYPE=default
     - BUILD_TYPE=default-Werror
@@ -29,31 +40,66 @@ env:
 #   - BUILD_TYPE=android
 #   - BUILD_TYPE=check-py
 
+pkg_deps_prereqs: &pkg_deps_prereqs
+    - libzmq3-dev
+    - libczmq-dev
+    - libmlm-dev
+
+pkg_deps_doctools: &pkg_deps_doctools
+    - asciidoc
+    - xmlto
+
+pkg_deps_devtools: &pkg_deps_devtools
+    - git
+
+pkg_src_zeromq_ubuntu12: &pkg_src_zeromq_ubuntu12
+- sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_12.04/ ./'
+  key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_12.04/Release.key'
+
+pkg_src_zeromq_ubuntu14: &pkg_src_zeromq_ubuntu14
+- sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/ ./'
+  key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/Release.key'
+
+# Note: refer to ubuntu14 if you use dist==Trusty
+addons:
+  apt:
+    sources: *pkg_src_zeromq_ubuntu12
+    packages: &pkg_deps_common
+    - *pkg_deps_devtools
+    - *pkg_deps_prereqs
+
 matrix:
   include:
+  - env: BUILD_TYPE=default-with-docs
+    os: linux
+    addons:
+      apt:
+        sources: *pkg_src_zeromq_ubuntu12
+        packages:
+        - *pkg_deps_common
+        - *pkg_deps_doctools
   - env: BUILD_TYPE=valgrind
     os: linux
     dist: trusty
-    sudo: required
+#    sudo: required
     addons:
       apt:
+        sources: *pkg_src_zeromq_ubuntu14
         packages:
         - valgrind
-
-addons:
-  sources:
-  - sourceline: 'deb http://download.opensuse.org/repositories/home:/zeromq:/git-draft/xUbuntu_12.04/ ./'
-    key_url: 'http://download.opensuse.org/repositories/home:/zeromq:/git-draft/xUbuntu_12.04/Release.key'
-  apt:
-    packages:
-    - asciidoc
-    - xmlto
-#    - libzmq3-dev
-#    - libczmq-dev
-#    - libmlm-dev
+        - *pkg_deps_common
+  - env: BUILD_TYPE=default ADDRESS_SANITIZER=enabled
+    os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources: *pkg_src_zeromq_ubuntu14
+        packages:
+        - *pkg_deps_common
 
 before_install:
-- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils valgrind ; fi
+- if [ "$TRAVIS_OS_NAME" == "osx" ] ; then brew update; brew install binutils ; fi
+- if [ "$TRAVIS_OS_NAME" == "osx" -a "$BUILD_TYPE" == "valgrind" ] ; then brew install valgrind ; fi
 
 # Hand off to generated script for each BUILD_TYPE
 script: ./ci_build.sh

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -25,7 +25,8 @@ case "$CI_TRACE" in
         set -x ;;
 esac
 
-if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ "$BUILD_TYPE" == "valgrind" ]; then
+case "$BUILD_TYPE" in
+default|default-Werror|default-with-docs|valgrind)
     LANG=C
     LC_ALL=C
     export LANG LC_ALL
@@ -111,7 +112,6 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
     CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
     CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
     CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
-    CONFIG_OPTS+=("--with-docs=no")
     if [ -z "${CI_CONFIG_QUIET-}" ] || [ "${CI_CONFIG_QUIET-}" = yes ] || [ "${CI_CONFIG_QUIET-}" = true ]; then
         CONFIG_OPTS+=("--quiet")
     fi
@@ -166,6 +166,13 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
         CONFIG_OPTS+=("CXX=${CXX}")
         CONFIG_OPTS+=("CPP=${CPP}")
     fi
+
+    if [ -n "$ADDRESS_SANITIZER" ] && [ "$ADDRESS_SANITIZER" == "enabled" ]; then
+        CONFIG_OPTS+=("--enable-address-sanitizer=yes")
+    fi
+
+    CONFIG_OPTS_COMMON=$CONFIG_OPTS
+    CONFIG_OPTS+=("--with-docs=no")
 
     # Clone and build dependencies, if not yet installed to Travis env as DEBs
     # or MacOS packages; other OSes are not currently supported by Travis cloud
@@ -272,6 +279,10 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
     echo "`date`: INFO: Starting build of currently tested project with DRAFT APIs..."
     CCACHE_BASEDIR=${PWD}
     export CCACHE_BASEDIR
+    if [ "$BUILD_TYPE" = "default-with-docs" ]; then
+        CONFIG_OPTS=$CONFIG_OPTS_COMMON
+        CONFIG_OPTS+=("--with-docs=yes")
+    fi
     # Only use --enable-Werror on projects that are expected to have it
     # (and it is not our duty to check prerequisite projects anyway)
     CONFIG_OPTS+=("${CONFIG_OPT_WERROR}")
@@ -323,9 +334,11 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
         echo "CCache stats after build:"
         ccache -s
     fi
-
-elif [ "$BUILD_TYPE" == "bindings" ]; then
+    ;;
+bindings)
     pushd "./bindings/${BINDING}" && ./ci_build.sh
-else
+    ;;
+*)
     pushd "./builds/${BUILD_TYPE}" && REPO_DIR="$(dirs -l +1)" ./ci_build.sh
-fi
+    ;;
+esac

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,7 @@ AC_PROG_AWK
 PKG_PROG_PKG_CONFIG
 
 # Code coverage
+AC_MSG_CHECKING([whether to enable GCov])
 AC_ARG_WITH(gcov, [AS_HELP_STRING([--with-gcov=yes/no],
                   [With GCC Code Coverage reporting])],
                   [FTY_PROTO_GCOV="$withval"])
@@ -64,8 +65,27 @@ if test "x${FTY_PROTO_GCOV}" == "xyes"; then
         CFLAGS="${CFLAGS} ${FTY_PROTO_ORIG_CFLAGS}"
     fi
     AM_CONDITIONAL(WITH_GCOV, true)
+    AC_MSG_RESULT([yes])
 else
     AM_CONDITIONAL(WITH_GCOV, false)
+    AC_MSG_RESULT([no])
+fi
+
+# Memory mis-use detection
+AC_MSG_CHECKING([whether to enable ASan])
+AC_ARG_ENABLE(address-sanitizer, [AS_HELP_STRING([--enable-address-sanitizer=yes/no],
+                  [Build with GCC Address Sanitizer instrumentation])],
+                  [FTY_PROTO_ASAN="$enableval"])
+
+if test "x${FTY_PROTO_ASAN}" == "xyes"; then
+    CFLAGS="${CFLAGS} -fsanitize=address"
+    CXXFLAGS="${CXXFLAGS} -fsanitize=address"
+
+    AM_CONDITIONAL(ENABLE_ASAN, true)
+    AC_MSG_RESULT([yes])
+else
+    AM_CONDITIONAL(ENABLE_ASAN, false)
+    AC_MSG_RESULT([no])
 fi
 
 # Set pkgconfigdir

--- a/project.xml
+++ b/project.xml
@@ -24,7 +24,7 @@
     <class name = "selftest" private="1">Selftest</class>
     <main  name = "generate_metric">Metric generator</main>
     <main  name = "get_metrics">Metrics getter</main>
-    <main name = "bmsg">Command line tool to work with fty proto messages</main>
+    <main  name = "bmsg">Command line tool to work with fty proto messages</main>
 
     <model name = "fty_proto" codec="zproto_codec_c_v1" />
 


### PR DESCRIPTION
Solution: Regenerated with recent zproject support for YAML references in .travis.yml, separated doc build job, and ASAN

Now that this works, our Travis CI runs no longer need to rebuild ZMQ, CZMQ and MLM - but just take them packaged (as long as the component source code is CZMQ4 compatible). Also the .travis.yml is easier to maintain for customized jobs, and more tests are done over the codebase.