### PR TITLE
Change the action field of alert messages to zlist

### DIFF
--- a/include/fty_proto.h
+++ b/include/fty_proto.h
@@ -106,8 +106,8 @@ The software maintains three main types of information divided to three streams
         description         string
         Alert description.
 
-        action              string
-        List of slash-separated ('/') actions, e.g.: "EMAIL/SMS".
+        action              strings
+        List of actions, e.g.: "EMAIL", "SMS".
         Can be empty.
 
 
@@ -257,7 +257,7 @@ zmsg_t *
         const char *state,
         const char *severity,
         const char *description,
-        const char *action);
+        zlist_t *action);
 
 //  Encode the ASSET
 zmsg_t *
@@ -292,7 +292,7 @@ int
         const char *state,
         const char *severity,
         const char *description,
-        const char *action);
+        zlist_t *action);
 
 //  Send the ASSET to the output in one step
 //  WARNING, this call will fail if output is of type ZMQ_ROUTER.
@@ -413,10 +413,24 @@ void
     fty_proto_set_description (fty_proto_t *self, const char *format, ...);
 
 //  Get/set the action field
-const char *
+zlist_t *
     fty_proto_action (fty_proto_t *self);
+//  Get the action field and transfer ownership to caller
+zlist_t *
+    fty_proto_get_action (fty_proto_t *self);
+//  Set the action field, transferring ownership from caller
 void
-    fty_proto_set_action (fty_proto_t *self, const char *format, ...);
+    fty_proto_set_action (fty_proto_t *self, zlist_t **action_p);
+
+//  Iterate through the action field, and append a action value
+const char *
+    fty_proto_action_first (fty_proto_t *self);
+const char *
+    fty_proto_action_next (fty_proto_t *self);
+void
+    fty_proto_action_append (fty_proto_t *self, const char *format, ...);
+size_t
+    fty_proto_action_size (fty_proto_t *self);
 
 //  Get/set the operation field
 const char *

--- a/src/fty_proto.bnf
+++ b/src/fty_proto.bnf
@@ -41,7 +41,7 @@ ACTIVE / ACK-WIP / ACK-IGNORE / ACK-PAUSE / ACK-SILENCE / RESOLVED
 Permissible values:
 INFO / WARNING / CRITICAL
     description     = string                ; Alert description.
-    action          = string                ; List of slash-separated ('/') actions, e.g.: "EMAIL/SMS".
+    action          = strings               ; List of actions, e.g.: "EMAIL", "SMS".
 Can be empty.
 
     ;  No description
@@ -62,6 +62,11 @@ A little explanation. Due to historical reasons:
 * 'inventory' is update of extended and/or auxilliary information
   (ext/aux field)
     ext             = hash                  ; Additional extended information.
+
+    ; A list of string values
+    strings         = strings-count *strings-value
+    strings-count   = number-4
+    strings-value   = longstr
 
     ; A list of name/value pairs
     hash            = hash-count *( hash-name hash-value )

--- a/src/fty_proto.xml
+++ b/src/fty_proto.xml
@@ -135,8 +135,8 @@
     </field>
 
 
-    <field name = "action" type = "string">
-        List of slash-separated ('/') actions, e.g.: "EMAIL/SMS".
+    <field name = "action" type = "strings">
+        List of actions, e.g.: "EMAIL", "SMS".
         Can be empty.
     </field>
 </message>


### PR DESCRIPTION
This allows us to easily extend it with different action types such as
GPO_INTEGRATION.

I suggest to hold off before we have fixes for the consumers of the affected API.