### PR TITLE
Sanity checks for fty_proto_is()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ CMake*
 libzmq/
 czmq/
 malamute/
+libsodium/
 
 # Travis build area
 tmp/

--- a/api/fty_proto.api
+++ b/api/fty_proto.api
@@ -45,9 +45,9 @@
     </destructor>
 
     <method name = "is" singleton = "1">
-        Parse a zmsg_t and decides whether it is fty_proto. Returns
-        true if it is, false otherwise. Doesn't destroy or modify the
-        original message.
+        Parses a zmsg_t and decides whether it carries a fty_proto.
+        Returns true if it does, false otherwise.
+        Doesn't destroy or modify the original message.
         <argument name = "msg" type = "zmsg" />
         <return type = "boolean" />
     </method>

--- a/bindings/lua_ffi/fty_proto_ffi.lua
+++ b/bindings/lua_ffi/fty_proto_ffi.lua
@@ -38,9 +38,9 @@ fty_proto_t *
 void
     fty_proto_destroy (fty_proto_t **self_p);
 
-// Parse a zmsg_t and decides whether it is fty_proto. Returns
-// true if it is, false otherwise. Doesn't destroy or modify the
-// original message.
+// Parses a zmsg_t and decides whether it carries a fty_proto.
+// Returns true if it does, false otherwise.
+// Doesn't destroy or modify the original message.
 bool
     fty_proto_is (zmsg_t *msg);
 

--- a/include/fty_proto.h
+++ b/include/fty_proto.h
@@ -206,9 +206,9 @@ fty_proto_t *
 void
     fty_proto_destroy (fty_proto_t **self_p);
 
-//  Parse a zmsg_t and decides whether it is fty_proto. Returns
-//  true if it is, false otherwise. Doesn't destroy or modify the
-//  original message.
+//  Parses a zmsg_t and decides whether it carries a fty_proto.
+//  Returns true if it does, false otherwise.
+//  Doesn't destroy or modify the original message.
 bool
     fty_proto_is (zmsg_t *msg_p);
 

--- a/src/fty_proto.c
+++ b/src/fty_proto.c
@@ -567,9 +567,9 @@ fty_proto_destroy (fty_proto_t **self_p)
     }
 }
 
-//  Parse a zmsg_t and decides whether it is fty_proto. Returns
-//  true if it is, false otherwise. Doesn't destroy or modify the
-//  original message.
+//  Parses a zmsg_t and decides whether it carries a fty_proto.
+//  Returns true if it does, false otherwise.
+//  Doesn't destroy or modify the original message.
 bool
 fty_proto_is (zmsg_t *msg)
 {

--- a/src/fty_proto.c
+++ b/src/fty_proto.c
@@ -575,6 +575,7 @@ fty_proto_is (zmsg_t *msg)
 {
     if (msg == NULL)
         return false;
+    assert (zmsg_is (msg));
 
     zframe_t *frame = zmsg_first (msg);
     if (frame == NULL)


### PR DESCRIPTION
Reduce doubt that we are manipulating random memory contents rather than expected objects. Or die on assertion failure.

UPDATE: testing for valid `fty_proto_t` proved more difficult (no apparent checksum/magic header). So while it was the original purpose of the PR, it is not here.