### PR TITLE
bmsg: Fix formatting of alertslist output

### DIFF
--- a/src/bmsg.c
+++ b/src/bmsg.c
@@ -800,8 +800,8 @@ int main (int argc, char *argv [])
                     bool first = true;
                     while (action) {
                         if (!first)
-                            puts(",");
-                        puts(action);
+                            fputs(",", stdout);
+                        fputs(action, stdout);
                         first = false;
                         action = fty_proto_action_next(decoded);
                     }


### PR DESCRIPTION
Each alert should be printed on a single line.

Fixes: c4b2a6cd94e8 ("Change the action field of alert messages to zlist")