### PR TITLE
[PQSWPRG-7595] Fix warnings due to asprintf() definition

### DIFF
--- a/src/bmsg.c
+++ b/src/bmsg.c
@@ -34,6 +34,15 @@
         goto exit; \
     } while (0);
 
+/* asprintf() */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
+#include <stdio.h>
+#undef _GNU_SOURCE
+#else
+#include <stdio.h>
+#endif
+
 #include "fty_proto_classes.h"
 
 static const int64_t STAT_INTERVAL = 10000;     // we'll count messages in 10 seconds intervals

--- a/src/generate_metric.c
+++ b/src/generate_metric.c
@@ -16,6 +16,15 @@ Copyright (C) 2014 - 2020 Eaton
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+/* asprintf() */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
+#include <stdio.h>
+#undef _GNU_SOURCE
+#else
+#include <stdio.h>
+#endif
+
 #include <fty_proto.h>
 #include <malamute.h>
 


### PR DESCRIPTION
Avoid this:

````
  CC       src/bmsg-bmsg.o
../../../.srcclone/LinuxDeb10-x86_64-czmq_3/fty-proto/src/bmsg.c: In function 'main':
../../../.srcclone/LinuxDeb10-x86_64-czmq_3/fty-proto/src/bmsg.c:394:9:
  error: implicit declaration of function 'asprintf';
  did you mean 'vsprintf'? [-Werror=implicit-function-declaration]
     r = asprintf (&address, "bmsg.%"PRIi64, zclock_mono ());
         ^~~~~~~~
         vsprintf
cc1: all warnings being treated as errors
````

and same in generate_metric.c
